### PR TITLE
Updating to latest p4 revision:

### DIFF
--- a/UnitTests/UnitTests_Serialization.cpp
+++ b/UnitTests/UnitTests_Serialization.cpp
@@ -68,9 +68,16 @@ using namespace JsonTests;
 bool test_json()
 {
 
+#ifdef _WIN32
+	sprawl::String expectedValue1 = "{ \"__version__\" : 0, \"t\" : { \"map\" : { \"test\" : 1.0000000000000001e-018, \"test2\" : 1e+022, \"test3\" : 1000000000 }, \"intArray\" : [ 1, -2, 3, -4, 5 ], \"strArray\" : [ \"hi\", \"there\", \"y'all\" ], \"nestedArray\" : [ [ 6, 7, 8, 9, 10 ] ], \"str\" : \"\\\\escapes\\\\ \\\" \\n\", \"i\" : 3, \"d\" : 2.5, \"b\" : true, \"c\" : \"f\", \"u\" : 32 } }";
+
+	sprawl::String expectedValue2 = "{\n\t\"__version__\" : 0,\n\t\"map\" : {\n\t\t\"test\" : 1.0000000000000001e-018,\n\t\t\"test2\" : 1e+022,\n\t\t\"test3\" : 1000000000\n\t},\n\t\"intArray\" : [\n\t\t1,\n\t\t-2,\n\t\t3,\n\t\t-4,\n\t\t5\n\t],\n\t\"strArray\" : [\n\t\t\"hi\",\n\t\t\"there\",\n\t\t\"y'all\"\n\t],\n\t\"nestedArray\" : [\n\t\t[\n\t\t\t6,\n\t\t\t7,\n\t\t\t8,\n\t\t\t9,\n\t\t\t10\n\t\t]\n\t],\n\t\"str\" : \"\\\\escapes\\\\ \\\" \\n\",\n\t\"i\" : 3,\n\t\"d\" : 2.5,\n\t\"b\" : true,\n\t\"c\" : \"f\",\n\t\"u\" : 32\n}";
+
+#else
 	sprawl::String expectedValue1 = "{ \"__version__\" : 0, \"t\" : { \"map\" : { \"test\" : 1.0000000000000000715e-18, \"test2\" : 1e+22, \"test3\" : 1000000000 }, \"intArray\" : [ 1, -2, 3, -4, 5 ], \"strArray\" : [ \"hi\", \"there\", \"y'all\" ], \"nestedArray\" : [ [ 6, 7, 8, 9, 10 ] ], \"str\" : \"\\\\escapes\\\\ \\\" \\n\", \"i\" : 3, \"d\" : 2.5, \"b\" : true, \"c\" : \"f\", \"u\" : 32 } }";
 
 	sprawl::String expectedValue2 = "{\n\t\"__version__\" : 0,\n\t\"map\" : {\n\t\t\"test\" : 1.0000000000000000715e-18,\n\t\t\"test2\" : 1e+22,\n\t\t\"test3\" : 1000000000\n\t},\n\t\"intArray\" : [\n\t\t1,\n\t\t-2,\n\t\t3,\n\t\t-4,\n\t\t5\n\t],\n\t\"strArray\" : [\n\t\t\"hi\",\n\t\t\"there\",\n\t\t\"y'all\"\n\t],\n\t\"nestedArray\" : [\n\t\t[\n\t\t\t6,\n\t\t\t7,\n\t\t\t8,\n\t\t\t9,\n\t\t\t10\n\t\t]\n\t],\n\t\"str\" : \"\\\\escapes\\\\ \\\" \\n\",\n\t\"i\" : 3,\n\t\"d\" : 2.5,\n\t\"b\" : true,\n\t\"c\" : \"f\",\n\t\"u\" : 32\n}";
+#endif
 
 	sprawl::String expectedTokValue = "{ \"test1\" : 1, \"test2\" : -2, \"object\" : { \"test1\" : 1, \"test2\" : -2, \"Tok\" : null }, \"array\" : [ -1, 2 ] }";
 	sprawl::String expectedTok2Value = "{ \"test1\" : -1, \"test2\" : 2, \"object\" : { \"test1\" : -1, \"test2\" : 2, \"Tok2\" : null }, \"array\" : [ 1, -2 ] }";

--- a/UnitTests/UnitTests_Thread.cpp
+++ b/UnitTests/UnitTests_Thread.cpp
@@ -3,6 +3,8 @@
 #include "../threading/condition_variable.hpp"
 #include "../time/time.hpp"
 #include "../threading/threadmanager.hpp"
+#include "../threading/threadlocal.hpp"
+#include "../threading/coroutine.hpp"
 
 #include <unordered_map>
 #include <unordered_set>
@@ -18,6 +20,10 @@ sprawl::threading::Handle mainThread = sprawl::this_thread::GetHandle();
 sprawl::threading::ThreadManager manager;
 
 std::unordered_map<int64_t, std::unordered_set<std::string>> threadCheck;
+std::unordered_map<int64_t, int> threadLocalCheck;
+sprawl::threading::ThreadLocal<int> threadLocalValue;
+std::unordered_map<int64_t, int*> threadLocalPtrCheck;
+sprawl::threading::ThreadLocal<int*> threadLocalPtr;
 
 void DoSomethingInAThread(int& i)
 {
@@ -36,10 +42,26 @@ void DoSomethingInAThread(int& i)
 	}
 }
 
+int curr = 0;
+
 bool shouldStop = false;
 void DoSomethingInAThread2(int& i, char const* const type)
 {
 	sprawl::threading::ScopedLock lock(mtx);
+
+	if(!threadLocalCheck.count(sprawl::this_thread::GetHandle().GetUniqueId()))
+	{
+		threadLocalValue = curr;
+		threadLocalCheck[sprawl::this_thread::GetHandle().GetUniqueId()] = curr++;
+		threadLocalPtrCheck[sprawl::this_thread::GetHandle().GetUniqueId()] = new int(0);
+		threadLocalPtr = threadLocalPtrCheck[sprawl::this_thread::GetHandle().GetUniqueId()];
+	}
+
+	if(*threadLocalValue != threadLocalCheck[sprawl::this_thread::GetHandle().GetUniqueId()] || *threadLocalPtr != threadLocalPtrCheck[sprawl::this_thread::GetHandle().GetUniqueId()])
+	{
+		printf("Thread local storage fail\n... ");
+		thread_success = false;
+	}
 
 	threadCheck[sprawl::this_thread::GetHandle().GetUniqueId()].insert(type);
 	if(threadCheck[sprawl::this_thread::GetHandle().GetUniqueId()].size() != 1)
@@ -59,6 +81,66 @@ void DoSomethingInAThread2(int& i, char const* const type)
 			shouldStop = true;
 		}
 	}
+}
+
+int count = 1;
+int mod = 2;
+
+void add()
+{
+	for(int idx = 0; idx < 10; ++idx)
+	{
+		count += mod;
+		sprawl::threading::Coroutine::Yield();
+	}
+}
+
+void mult()
+{
+	for(int idx = 0; idx < 10; ++idx)
+	{
+		count *= mod;
+		sprawl::threading::Coroutine::Yield();
+	}
+}
+
+void addOverTime(int start)
+{
+	for(;;)
+	{
+		start += sprawl::threading::Coroutine::Receive<int, int>(start);
+	}
+}
+
+int addOverTime2Value;
+
+void addOverTime2(int start)
+{
+	addOverTime2Value = start;
+	for(;;)
+	{
+		addOverTime2Value += sprawl::threading::Coroutine::Receive<int>();
+	}
+}
+
+void addOverTime3(int start)
+{
+	for(;;)
+	{
+		sprawl::threading::Coroutine::Yield(++start);
+	}
+}
+
+sprawl::threading::Generator<int> numberGenerator(int start)
+{
+	auto generator = [](int start)
+	{
+		for(;;)
+		{
+			sprawl::threading::Coroutine::Yield(start++);
+		}
+	};
+	return sprawl::threading::Generator<int>(std::bind(generator, start));
 }
 
 bool test_thread()
@@ -96,11 +178,11 @@ bool test_thread()
 	int k = 0;
 	manager.AddThreads(1, 5);
 	manager.AddThreads(2, 5);
-	for(int count = 0; count < 100; ++count)
+	for(int idx = 0; idx < 100; ++idx)
 	{
 		manager.AddTask(std::bind(DoSomethingInAThread2, std::ref(j), "1"), 1);
 	}
-	for(int count = 0; count < 100; ++count)
+	for(int idx = 0; idx < 100; ++idx)
 	{
 		manager.AddFutureTask(std::bind(DoSomethingInAThread2, std::ref(k), "2"), 2, sprawl::time::Resolution::Seconds * 2);
 	}
@@ -111,6 +193,111 @@ bool test_thread()
 	{
 		printf("ThreadManager increment failed. %d %d\n... ", j, k);
 		thread_success = false;
+	}
+
+	sprawl::threading::Coroutine addCrt(add);
+	sprawl::threading::Coroutine multCrt(mult);
+
+	bool continuing = true;
+	while(continuing)
+	{
+		continuing = false;
+		if(addCrt.State() != sprawl::threading::Coroutine::CoroutineState::Completed)
+		{
+			continuing = true;
+			addCrt();
+		}
+		if(multCrt.State() != sprawl::threading::Coroutine::CoroutineState::Completed)
+		{
+			continuing = true;
+			multCrt.Resume();
+		}
+	}
+	//Order of operations test - if the two functions didn't alternate as intended this will fail.
+	if(count != ((((((((((((((((((((1+2)*2)+2)*2)+2)*2)+2)*2)+2)*2)+2)*2)+2)*2)+2)*2)+2)*2)+2)*2))
+	{
+		printf("Coroutines failed. %d\n... ", count);
+		thread_success = false;
+	}
+
+	sprawl::threading::CoroutineWithChannel<int,int> addOverTimeCrt(std::bind(addOverTime, 1));
+	int num = addOverTimeCrt.Start();
+	for(int j = 0; j < 10; ++j)
+	{
+		if(j % 2 == 0)
+		{
+			num = addOverTimeCrt.Send(num);
+		}
+		else
+		{
+			num = addOverTimeCrt(num);
+		}
+	}
+	if(num != 1 + 1 + 2 + 4 + 8 + 16 + 32 + 64 + 128 + 256 + 512)
+	{
+		printf("Coroutine with channel failed. %d\n... ", num);
+		thread_success = false;
+	}
+
+	sprawl::threading::CoroutineWithChannel<int, void> addOverTime2Crt(std::bind(addOverTime2, 1));
+	num = 1;
+	addOverTime2Crt.Start();
+	for(int j = 0; j < 10; ++j)
+	{
+		if(j % 2 == 0)
+		{
+			addOverTime2Crt.Send(num);
+		}
+		else
+		{
+			addOverTime2Crt(num);
+		}
+	}
+	if(addOverTime2Value != 11)
+	{
+		printf("Coroutine with channel failed. %d\n... ", addOverTime2Value);
+		thread_success = false;
+	}
+
+	sprawl::threading::CoroutineWithChannel<void, int> addOverTime3Crt(std::bind(addOverTime3, 1));
+	num = 1;
+	for(int j = 0; j < 10; ++j)
+	{
+		if(j % 2 == 0)
+		{
+			num += addOverTime3Crt.Resume();
+		}
+		else
+		{
+			num += addOverTime3Crt();
+		}
+	}
+	if(num != 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11)
+	{
+		printf("Coroutine with channel failed. %d\n... ", num);
+		thread_success = false;
+	}
+
+	sprawl::threading::Generator<int> generator = numberGenerator(1);
+
+	for(int i = 1; i < 10; ++i)
+	{
+		if(i % 2 != 0)
+		{
+			if(generator.Resume() != i)
+			{
+				printf("Generator failed. %d\n... ", num);
+				thread_success = false;
+			}
+		}
+		else
+		{
+			if(generator() != i)
+			{
+				printf("Generator failed. %d\n... ", num);
+				thread_success = false;
+			}
+		}
 	}
 
 	return thread_success;

--- a/UnitTests/UnitTests_Time.cpp
+++ b/UnitTests/UnitTests_Time.cpp
@@ -1,6 +1,7 @@
 #include "../time/time.hpp"
 #include <chrono>
 #include <iostream>
+#include "../threading/thread.hpp"
 
 bool test_time()
 {
@@ -9,7 +10,7 @@ bool test_time()
 	{
 		typedef std::chrono::system_clock clock;
 		clock::time_point t = clock::now();
-		clock::duration nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch());
+		auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch());
 		int64_t startTime = nanoseconds.count();
 
 		int64_t now = sprawl::time::Now(sprawl::time::Resolution::Nanoseconds);
@@ -24,11 +25,34 @@ bool test_time()
 			printf("System time is not in sync with std::chrono\n...");
 		}
 	}
-
+#ifdef _WIN32
 	{
 		typedef std::chrono::steady_clock clock;
 		clock::time_point t = clock::now();
-		clock::duration nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch());
+		auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch());
+		int64_t startTime = nanoseconds.count();
+		int64_t sprawlStartTime = sprawl::time::SteadyNow(sprawl::time::Resolution::Nanoseconds);
+
+		sprawl::this_thread::Sleep(1000 * sprawl::time::Resolution::Milliseconds);
+
+		t = clock::now();
+		nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch());
+		int64_t endTime = nanoseconds.count();
+		int64_t sprawlEndTime = sprawl::time::SteadyNow(sprawl::time::Resolution::Nanoseconds);
+
+		int64_t delta = endTime - startTime;
+		int64_t sprawlDelta = sprawlEndTime - sprawlStartTime;
+		if(abs(sprawlDelta - delta) > 1000000)
+		{
+			success = false;
+			printf("Steady time is not in sync with std::chrono\n...");
+		}
+	}
+#else
+	{
+		typedef std::chrono::steady_clock clock;
+		clock::time_point t = clock::now();
+		auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch());
 		int64_t startTime = nanoseconds.count();
 
 		int64_t now = sprawl::time::SteadyNow(sprawl::time::Resolution::Nanoseconds);
@@ -43,6 +67,7 @@ bool test_time()
 			printf("Steady time is not in sync with std::chrono\n...");
 		}
 	}
+#endif
 
 	int64_t timeInMilliseconds = 10000;
 	int64_t timeInSeconds = sprawl::time::Convert(timeInMilliseconds, sprawl::time::Resolution::Milliseconds, sprawl::time::Resolution::Seconds);

--- a/UnitTests/main.cpp
+++ b/UnitTests/main.cpp
@@ -3,14 +3,28 @@
 #include <string>
 #include <tuple>
 #include <string.h>
+#include "../threading/condition_variable.hpp"
+
+extern sprawl::threading::ConditionVariable cond;
+sprawl::threading::ConditionVariable cond2;
+extern bool test_thread();
+
+class blah
+{
+public:
+	static sprawl::threading::ConditionVariable cond3;
+};
+sprawl::threading::ConditionVariable blah::cond3;
 
 int main(int argc, char* argv[])
 {
+	cond.NotifyAll();
+	blah::cond3.NotifyAll();
 	std::vector<std::tuple<std::string, bool, bool(*)(void)>> tests;
 
 #define ADD_TEST(name) extern bool test_##name(); tests.push_back(std::make_tuple(#name, false, &test_##name))
 
-	ADD_TEST(memory);
+	//ADD_TEST(memory);
 	ADD_TEST(hashmap);
 	ADD_TEST(list);
 	ADD_TEST(string);

--- a/common/compat.hpp
+++ b/common/compat.hpp
@@ -18,19 +18,23 @@
 
 #if defined(__GNUC__) || defined(__INTEL_COMPILER)
 #	define SPRAWL_MEMCMP __builtin_memcmp
-#	ifdef _MULTI_THREADED
-#		define SPRAWL_MULTITHREADED 1
-#	else
-#		define SPRAWL_MULTITHREADED 0
+#	ifndef SPRAWL_MULTITHREADED
+#		ifdef _REENTRANT
+#			define SPRAWL_MULTITHREADED 1
+#		else
+#			define SPRAWL_MULTITHREADED 0
+#		endif
 #	endif
 #	define SPRAWL_FORCEINLINE inline __attribute__((always_inline))
 #	define SPRAWL_CONSTEXPR constexpr
 #else
 #	define SPRAWL_MEMCMP memcmp
-#	ifdef _MT
-#		define SPRAWL_MULTITHREADED 1
-#	else
-#		define SPRAWL_MULTITHREADED 0
+#	ifndef SPRAWL_MULTITHREADED
+#		ifdef _MT
+#			define SPRAWL_MULTITHREADED 1
+#		else
+#			define SPRAWL_MULTITHREADED 0
+#		endif
 #	endif
 #	define SPRAWL_FORCEINLINE inline __forceinline
 #	define SPRAWL_CONSTEXPR const

--- a/string/String.hpp
+++ b/string/String.hpp
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <unordered_map>
 
+#include <atomic>
+
 namespace sprawl
 {
 	class StringLiteral;
@@ -52,7 +54,7 @@ namespace sprawl
 			char m_staticData[staticDataSize];
 			char* m_dynamicData;
 			const char* m_data;
-			int m_refCount;
+			std::atomic<int> m_refCount;
 			size_t m_length;
 			mutable size_t m_hash;
 			mutable bool m_hashComputed;

--- a/string/StringBuilder.cpp
+++ b/string/StringBuilder.cpp
@@ -196,13 +196,25 @@ namespace sprawl
 		return *this;
 	}
 
+	StringBuilder& StringBuilder::operator<<(StringLiteral const& elem)
+	{
+		char buf[15];
+#ifdef _WIN32
+		_snprintf(buf, 15, "%%%Iu.%Ius", elem.GetLength(), elem.GetLength());
+#else
+		snprintf(buf, 15, "%%%zu.%zus", elem.GetLength(), elem.GetLength());
+#endif
+		checked_snprintf(buf, elem.GetPtr());
+		return *this;
+	}
+
 	StringBuilder& StringBuilder::operator<<(String const& elem)
 	{
-		char buf[8];
+		char buf[15];
 #ifdef _WIN32
-		_snprintf(buf, 8, "%%.%Ius", elem.length());
+		_snprintf(buf, 15, "%%%Iu.%Ius", elem.length(), elem.length());
 #else
-		snprintf(buf, 8, "%%.%zus", elem.length());
+		snprintf(buf, 15, "%%%zu.%zus", elem.length(), elem.length());
 #endif
 		checked_snprintf(buf, elem.c_str());
 		return *this;
@@ -210,11 +222,11 @@ namespace sprawl
 
 	StringBuilder& StringBuilder::operator<<(std::string const& elem)
 	{
-		char buf[8];
+		char buf[15];
 #ifdef _WIN32
-		_snprintf(buf, 8, "%%.%Ius", elem.length());
+		_snprintf(buf, 15, "%%%Iu.%Ius", elem.length(), elem.length());
 #else
-		snprintf(buf, 8, "%%.%zus", elem.length());
+		snprintf(buf, 15, "%%%zu.%zus", elem.length(), elem.length());
 #endif
 		checked_snprintf(buf, elem.c_str());
 		return *this;
@@ -664,17 +676,36 @@ namespace sprawl
 		checked_snprintf(buf, elem);
 	}
 
-	void StringBuilder::AppendElementToBuffer(String const& elem, char const* const modifiers)
+	void StringBuilder::AppendElementToBuffer(StringLiteral const& elem, char const* const /*modifiers*/)
 	{
 		char buf[15];
-		sprintf(buf, "%%%ss", modifiers);
+#ifdef _WIN32
+		_snprintf(buf, 15, "%%%Iu.%Ius", elem.GetLength(), elem.GetLength());
+#else
+		snprintf(buf, 15, "%%%zu.%zus", elem.GetLength(), elem.GetLength());
+#endif
+		checked_snprintf(buf, elem.GetPtr());
+	}
+
+	void StringBuilder::AppendElementToBuffer(String const& elem, char const* const /*modifiers*/)
+	{
+		char buf[15];
+#ifdef _WIN32
+		_snprintf(buf, 15, "%%%Iu.%Ius", elem.length(), elem.length());
+#else
+		snprintf(buf, 15, "%%%zu.%zus", elem.length(), elem.length());
+#endif
 		checked_snprintf(buf, elem.c_str());
 	}
 
-	void StringBuilder::AppendElementToBuffer(std::string const& elem, char const* const modifiers)
+	void StringBuilder::AppendElementToBuffer(std::string const& elem, char const* const /*modifiers*/)
 	{
 		char buf[15];
-		sprintf(buf, "%%%ss", modifiers);
+#ifdef _WIN32
+		_snprintf(buf, 15, "%%%Iu.%Ius", elem.length(), elem.length());
+#else
+		snprintf(buf, 15, "%%%zu.%zus", elem.length(), elem.length());
+#endif
 		checked_snprintf(buf, elem.c_str());
 	}
 

--- a/string/StringBuilder.hpp
+++ b/string/StringBuilder.hpp
@@ -13,6 +13,7 @@
 namespace sprawl
 {
 	class String;
+	class StringLiteral;
 
 	class StringBuilder
 	{
@@ -38,6 +39,7 @@ namespace sprawl
 		StringBuilder& operator<<(char const elem);
 		StringBuilder& operator<<(char const* const elem);
 		StringBuilder& operator<<(String const& elem);
+		StringBuilder& operator<<(StringLiteral const& elem);
 
 #ifndef SPRAWL_STRING_NO_STL_COMPAT
 		StringBuilder& operator<<(std::string const& elem);
@@ -62,6 +64,7 @@ namespace sprawl
 		void AppendElementToBuffer(char const elem, char const* const modifiers);
 		void AppendElementToBuffer(char const* const elem, char const* const modifiers);
 		void AppendElementToBuffer(String const& elem, char const* const modifiers);
+		void AppendElementToBuffer(StringLiteral const& elem, char const* const modifiers);
 #ifndef SPRAWL_STRING_NO_STL_COMPAT
 		void AppendElementToBuffer(std::string const& elem, char const* const modifiers);
 #endif

--- a/threading/Coroutine.hpp.autosave
+++ b/threading/Coroutine.hpp.autosave
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <functional>
+
+namespace sprawl
+{
+	namespace threading
+	{
+		class Coroutine;
+	}
+}
+
+class Coroutine
+{
+public:
+	Coroutine();
+};

--- a/threading/coroutine.cpp
+++ b/threading/coroutine.cpp
@@ -1,0 +1,113 @@
+#include "coroutine.hpp"
+
+
+/*static*/ sprawl::threading::ThreadLocal<sprawl::threading::Coroutine*> sprawl::threading::Coroutine::ms_coroutineInitHelper;
+/*static*/ sprawl::threading::ThreadLocal<sprawl::threading::Coroutine> sprawl::threading::Coroutine::ms_thisThreadCoroutine;
+
+/*static*/ void sprawl::threading::Coroutine::Yield()
+{
+	Coroutine routine = *Coroutine::ms_thisThreadCoroutine;
+	routine.Pause();
+}
+
+sprawl::threading::Coroutine::Holder* sprawl::threading::Coroutine::Holder::Create()
+{
+	typedef memory::DynamicPoolAllocator<sizeof(Holder)> holderAlloc;
+
+	Holder* ret = (Holder*)holderAlloc::alloc();
+	new(ret) Holder();
+	return ret;
+}
+
+sprawl::threading::Coroutine::Holder* sprawl::threading::Coroutine::Holder::Create(std::function<void()> function, size_t stackSize)
+{
+	typedef memory::DynamicPoolAllocator<sizeof(Holder)> holderAlloc;
+
+	Holder* ret = (Holder*)holderAlloc::alloc();
+	new(ret) Holder(function, stackSize);
+	return ret;
+}
+
+void sprawl::threading::Coroutine::Holder::Release()
+{
+	typedef memory::DynamicPoolAllocator<sizeof(Holder)> holderAlloc;
+
+	this->~Holder();
+	holderAlloc::free(this);
+}
+
+void sprawl::threading::Coroutine::Holder::IncRef()
+{
+	++m_refCount;
+}
+
+bool sprawl::threading::Coroutine::Holder::DecRef()
+{
+	return (--m_refCount == 0);
+}
+
+sprawl::threading::Coroutine::Coroutine(std::function<void()> function, size_t stackSize)
+	: m_holder(Holder::Create(function, stackSize))
+{
+	if(!ms_thisThreadCoroutine)
+	{
+		ms_thisThreadCoroutine = Coroutine();
+	}
+}
+
+sprawl::threading::Coroutine::Coroutine()
+	: m_holder(Holder::Create())
+{
+	// NOP
+}
+
+sprawl::threading::Coroutine::Coroutine(sprawl::threading::Coroutine::Holder* holder)
+	: m_holder(holder)
+{
+	if(m_holder && !ms_thisThreadCoroutine)
+	{
+		ms_thisThreadCoroutine = Coroutine();
+	}
+}
+
+sprawl::threading::Coroutine::Coroutine(Coroutine const& other)
+	: m_holder(other.m_holder)
+{
+	m_holder->IncRef();
+}
+
+sprawl::threading::Coroutine& sprawl::threading::Coroutine::operator =(Coroutine const& other)
+{
+	if(m_holder && m_holder->DecRef())
+	{
+		m_holder->Release();
+	}
+	m_holder = other.m_holder;
+	m_holder->IncRef();
+	return *this;
+}
+
+sprawl::threading::Coroutine::~Coroutine()
+{
+	if(m_holder && m_holder->DecRef())
+	{
+		m_holder->Release();
+	}
+}
+
+sprawl::threading::Coroutine::CoroutineState sprawl::threading::Coroutine::State()
+{
+	return m_holder->m_state;
+}
+
+void sprawl::threading::Coroutine::run_()
+{
+	m_holder->m_function();
+	m_holder->m_state = CoroutineState::Completed;
+	m_holder->m_priorCoroutine.reactivate_();
+}
+
+/*static*/ void sprawl::threading::Coroutine::entryPoint_()
+{
+	ms_coroutineInitHelper->run_();
+}

--- a/threading/coroutine.hpp
+++ b/threading/coroutine.hpp
@@ -1,0 +1,397 @@
+#pragma once
+
+#include <functional>
+#include "threadlocal.hpp"
+#include <atomic>
+#include "../memory/PoolAllocator.hpp"
+
+#ifdef _WIN32
+#	undef Yield
+#else
+#	include <ucontext.h>
+#endif
+
+///TODO:
+/// - Get rid of std::shared_ptr, make coroutines have shared data instead
+/// - Get rid of std::function, allow Start() to accept function parameters
+/// - Windows implementation
+
+namespace sprawl
+{
+	namespace threading
+	{
+		class Coroutine;
+
+		template<typename SendType, typename ReceiveType>
+		class CoroutineWithChannel;
+
+		template<typename ReturnType>
+		using Generator = CoroutineWithChannel<void, ReturnType>;
+	}
+}
+
+class sprawl::threading::Coroutine
+{
+public:
+
+	enum class CoroutineState
+	{
+		Created,
+		Executing,
+		Paused,
+		Completed,
+	};
+
+	static void Yield();
+
+	template<typename SendType, typename ReceiveType>
+	static SendType& Receive(ReceiveType const& value);
+
+	template<typename SendType>
+	static SendType& Receive();
+
+	template<typename ReceiveType>
+	static void Yield(ReceiveType const& value);
+
+	Coroutine();
+	Coroutine(std::function<void ()> function, size_t stackSize = 0);
+
+	Coroutine(Coroutine const& other);
+
+	Coroutine& operator=(Coroutine const& other);
+
+	virtual ~Coroutine();
+
+	void Start() { Resume(); }
+	void Pause();
+	void Resume();
+	void Reset();
+
+	void operator()() { Resume(); }
+
+	CoroutineState State();
+protected:
+	static ThreadLocal<Coroutine*> ms_coroutineInitHelper;
+	static ThreadLocal<Coroutine> ms_thisThreadCoroutine;
+
+	static void entryPoint_();
+	void run_();
+	void reactivate_();
+
+	struct Holder;
+
+	explicit Coroutine(Holder* holder);
+
+	Holder* m_holder;
+};
+
+struct sprawl::threading::Coroutine::Holder
+{
+	void IncRef();
+	bool DecRef();
+
+	std::function<void ()> m_function;
+	size_t m_stackSize;
+	void* m_stack;
+	void* m_stackPointer;
+	CoroutineState m_state;
+
+	#ifndef _WIN32
+		ucontext_t m_context;
+	#endif
+
+	std::atomic<int> m_refCount;
+
+	Coroutine m_priorCoroutine;
+
+	static Holder* Create(std::function<void()> function, size_t stackSize);
+	static Holder* Create();
+	virtual void Release();
+
+	virtual ~Holder() {}
+protected:
+	Holder();
+	Holder(std::function<void()> function, size_t stackSize);
+};
+
+template<typename SendType, typename ReceiveType>
+class sprawl::threading::CoroutineWithChannel : public sprawl::threading::Coroutine
+{
+public:
+	CoroutineWithChannel(std::function<void ()> function, size_t stackSize = 0)
+		: Coroutine(ChannelHolder::Create(function, stackSize))
+	{
+		// NOP
+	}
+
+	CoroutineWithChannel(Coroutine const& other)
+		: Coroutine(other)
+	{
+		// NOP
+	}
+
+	SendType& Receive(ReceiveType const& value)
+	{
+		reinterpret_cast<ChannelHolder*>(m_holder)->m_receivedValue = value;
+		Pause();
+		return reinterpret_cast<ChannelHolder*>(m_holder)->m_sentValue;
+	}
+
+	ReceiveType& Send(SendType const& value)
+	{
+		reinterpret_cast<ChannelHolder*>(m_holder)->m_sentValue = value;
+		Resume();
+		return reinterpret_cast<ChannelHolder*>(m_holder)->m_receivedValue;
+	}
+
+	SendType& Receive(ReceiveType&& value)
+	{
+		reinterpret_cast<ChannelHolder*>(m_holder)->m_receivedValue = std::move(value);
+		Pause();
+		return reinterpret_cast<ChannelHolder*>(m_holder)->m_sentValue;
+	}
+
+	ReceiveType& Send(SendType&& value)
+	{
+		reinterpret_cast<ChannelHolder*>(m_holder)->m_sentValue = std::move(value);
+		Resume();
+		return reinterpret_cast<ChannelHolder*>(m_holder)->m_receivedValue;
+	}
+
+	ReceiveType& Start()
+	{
+		Resume();
+		return reinterpret_cast<ChannelHolder*>(m_holder)->m_receivedValue;
+	}
+
+	ReceiveType& operator()()
+	{
+		return Start();
+	}
+
+	ReceiveType& operator()(SendType const& value)
+	{
+		return Send(value);
+	}
+
+	ReceiveType& operator()(SendType&& value)
+	{
+		return Send(std::move(value));
+	}
+
+private:
+
+	struct ChannelHolder : public Coroutine::Holder
+	{
+		static ChannelHolder* Create(std::function<void()> function, size_t stackSize)
+		{
+			typedef memory::DynamicPoolAllocator<sizeof(ChannelHolder)> holderAlloc;
+
+			ChannelHolder* ret = (ChannelHolder*)holderAlloc::alloc();
+			new(ret) ChannelHolder(function, stackSize);
+			return ret;
+		}
+
+		virtual void Release() override
+		{
+			typedef memory::DynamicPoolAllocator<sizeof(ChannelHolder)> holderAlloc;
+
+			this->~ChannelHolder();
+			holderAlloc::free(this);
+		}
+
+		ChannelHolder(std::function<void()> function, size_t stackSize)
+			: Holder(function, stackSize)
+			, m_sentValue()
+			, m_receivedValue()
+		{
+			// NOP
+		}
+
+		SendType m_sentValue;
+		ReceiveType m_receivedValue;
+	};
+};
+
+template<typename SendType>
+class sprawl::threading::CoroutineWithChannel<SendType, void> : public sprawl::threading::Coroutine
+{
+public:
+	CoroutineWithChannel(std::function<void ()> function, size_t stackSize = 0)
+		: Coroutine(ChannelHolder::Create(function, stackSize))
+	{
+		// NOP
+	}
+
+	CoroutineWithChannel(Coroutine const& other)
+		: Coroutine(other)
+	{
+		// NOP
+	}
+
+	SendType& Receive()
+	{
+		Pause();
+		return reinterpret_cast<ChannelHolder*>(m_holder)->m_sentValue;
+	}
+
+	void Send(SendType const& value)
+	{
+		reinterpret_cast<ChannelHolder*>(m_holder)->m_sentValue = value;
+		Resume();
+	}
+
+	void Send(SendType&& value)
+	{
+		reinterpret_cast<ChannelHolder*>(m_holder)->m_sentValue = std::move(value);
+		Resume();
+	}
+
+	using Coroutine::operator();
+
+	void operator()(SendType const& value)
+	{
+		Send(value);
+	}
+
+	void operator()(SendType&& value)
+	{
+		Send(std::move(value));
+	}
+
+private:
+
+	struct ChannelHolder : public Coroutine::Holder
+	{
+		static ChannelHolder* Create(std::function<void()> function, size_t stackSize = 0)
+		{
+			typedef memory::DynamicPoolAllocator<sizeof(ChannelHolder)> holderAlloc;
+
+			ChannelHolder* ret = (ChannelHolder*)holderAlloc::alloc();
+			new(ret) ChannelHolder(function, stackSize);
+			return ret;
+		}
+
+		virtual void Release() override
+		{
+			typedef memory::DynamicPoolAllocator<sizeof(ChannelHolder)> holderAlloc;
+
+			this->~ChannelHolder();
+			holderAlloc::free(this);
+		}
+
+		ChannelHolder(std::function<void()> function, size_t stackSize)
+			: Holder(function, stackSize)
+			, m_sentValue()
+		{
+			// NOP
+		}
+
+		SendType m_sentValue;
+	};
+};
+
+template<typename ReceiveType>
+class sprawl::threading::CoroutineWithChannel<void, ReceiveType> : public sprawl::threading::Coroutine
+{
+public:
+	CoroutineWithChannel(std::function<void ()> function, size_t stackSize = 0)
+		: Coroutine(ChannelHolder::Create(function, stackSize))
+	{
+		// NOP
+	}
+
+	CoroutineWithChannel(Coroutine const& other)
+		: Coroutine(other)
+	{
+		// NOP
+	}
+
+	void Yield(ReceiveType const& value)
+	{
+		reinterpret_cast<ChannelHolder*>(m_holder)->m_receivedValue = value;
+		Pause();
+	}
+
+	void Yield(ReceiveType&& value)
+	{
+		reinterpret_cast<ChannelHolder*>(m_holder)->m_receivedValue = std::move(value);
+		Pause();
+	}
+
+	ReceiveType& Resume()
+	{
+		Coroutine::Resume();
+		return reinterpret_cast<ChannelHolder*>(m_holder)->m_receivedValue;
+	}
+
+	ReceiveType& Start()
+	{
+		return Resume();
+	}
+
+	ReceiveType& operator()()
+	{
+		return Resume();
+	}
+
+private:
+	struct ChannelHolder : public Coroutine::Holder
+	{
+		static ChannelHolder* Create(std::function<void()> function, size_t stackSize)
+		{
+			typedef memory::DynamicPoolAllocator<sizeof(ChannelHolder)> holderAlloc;
+
+			ChannelHolder* ret = (ChannelHolder*)holderAlloc::alloc();
+			new(ret) ChannelHolder(function, stackSize);
+			return ret;
+		}
+
+		virtual void Release() override
+		{
+			typedef memory::DynamicPoolAllocator<sizeof(ChannelHolder)> holderAlloc;
+
+			this->~ChannelHolder();
+			holderAlloc::free(this);
+		}
+
+		ChannelHolder(std::function<void()> function, size_t stackSize)
+			: Holder(function, stackSize)
+			, m_receivedValue()
+		{
+			// NOP
+		}
+
+		ReceiveType m_receivedValue;
+	};
+};
+
+template<>
+class sprawl::threading::CoroutineWithChannel<void, void> : public sprawl::threading::Coroutine
+{
+
+};
+
+template<typename SendType, typename ReceiveType>
+/*static*/ SendType& sprawl::threading::Coroutine::Receive(ReceiveType const& value)
+{
+	Coroutine crt = *Coroutine::ms_thisThreadCoroutine;
+	CoroutineWithChannel<SendType, ReceiveType> withChannel = crt;
+	return withChannel.Receive(value);
+}
+
+template<typename SendType>
+/*static*/ SendType& sprawl::threading::Coroutine::Receive()
+{
+	Coroutine crt = *Coroutine::ms_thisThreadCoroutine;
+	CoroutineWithChannel<SendType, void> withChannel = crt;
+	return withChannel.Receive();
+}
+
+template<typename ReceiveType>
+/*static*/ void sprawl::threading::Coroutine::Yield(ReceiveType const& value)
+{
+	Coroutine crt = *Coroutine::ms_thisThreadCoroutine;
+	CoroutineWithChannel<void, ReceiveType> withChannel = crt;
+	withChannel.Yield(value);
+}

--- a/threading/coroutine_linux.cpp
+++ b/threading/coroutine_linux.cpp
@@ -1,0 +1,77 @@
+#include "coroutine.hpp"
+#include "threadlocal.hpp"
+
+#include <sys/mman.h>
+
+sprawl::threading::Coroutine::Holder::Holder()
+	: m_function(nullptr)
+	, m_stackSize(0)
+	, m_stack(nullptr)
+	, m_stackPointer(nullptr)
+	, m_state(CoroutineState::Created)
+	, m_context()
+	, m_refCount(1)
+	, m_priorCoroutine(nullptr)
+{
+	m_stackPointer = &m_context;
+
+	getcontext(&m_context);
+}
+
+sprawl::threading::Coroutine::Holder::Holder(std::function<void()> function, size_t stackSize)
+	: m_function(function)
+	, m_stackSize(stackSize == 0 ? 1024 * 1024 : stackSize)
+	, m_stack(nullptr)
+	, m_stackPointer(nullptr)
+	, m_state(CoroutineState::Created)
+	, m_context()
+	, m_refCount(1)
+	, m_priorCoroutine(nullptr)
+{
+	m_stack = mmap(NULL, m_stackSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+
+	m_stackPointer = &m_context;
+
+	getcontext(&m_context);
+
+	m_context.uc_link = nullptr;
+	m_context.uc_stack.ss_sp = m_stack;
+	m_context.uc_stack.ss_size = m_stackSize;
+
+	makecontext(&m_context, &Coroutine::entryPoint_, 0);
+}
+
+void sprawl::threading::Coroutine::Resume()
+{
+	m_holder->m_state = CoroutineState::Executing;
+
+	m_holder->m_priorCoroutine = *ms_thisThreadCoroutine;
+
+	ms_thisThreadCoroutine = *this;
+
+	m_holder->m_priorCoroutine.m_holder->m_state = CoroutineState::Paused;
+
+	ms_coroutineInitHelper = this;
+	swapcontext(&m_holder->m_priorCoroutine.m_holder->m_context, &m_holder->m_context);
+}
+
+void sprawl::threading::Coroutine::reactivate_()
+{
+	m_holder->m_state = CoroutineState::Executing;
+
+	Coroutine currentlyActiveCoroutine = *ms_thisThreadCoroutine;
+	ms_thisThreadCoroutine = *this;
+
+	swapcontext(&currentlyActiveCoroutine.m_holder->m_context, &m_holder->m_context);
+}
+
+void sprawl::threading::Coroutine::Pause()
+{
+	m_holder->m_state = CoroutineState::Paused;
+
+	ms_thisThreadCoroutine = m_holder->m_priorCoroutine;
+
+	m_holder->m_priorCoroutine.m_holder->m_state = CoroutineState::Executing;
+
+	swapcontext(&m_holder->m_context, &m_holder->m_priorCoroutine.m_holder->m_context);
+}

--- a/threading/coroutine_windows.cpp
+++ b/threading/coroutine_windows.cpp
@@ -1,0 +1,76 @@
+#include "coroutine.hpp"
+#include "threadlocal.hpp"
+#include <Windows.h>
+
+namespace CoroutineStatic
+{
+	static VOID CALLBACK EntryPoint(PVOID lpParameter)
+	{
+		typedef void(*entryPoint)();
+		entryPoint ep = (entryPoint)(lpParameter);
+		ep();
+	}
+}
+
+sprawl::threading::Coroutine::Holder::Holder()
+	: m_function(nullptr)
+	, m_stackSize(0)
+	, m_stack(nullptr)
+	, m_stackPointer(nullptr)
+	, m_state(CoroutineState::Created)
+	, m_refCount(1)
+	, m_priorCoroutine(nullptr)
+{
+	if(!IsThreadAFiber())
+	{
+		ConvertThreadToFiber(nullptr);
+	}
+	m_stackPointer = GetCurrentFiber();
+}
+
+sprawl::threading::Coroutine::Holder::Holder(std::function<void()> function, size_t /*stackSize*/)
+	: m_function(function)
+	, m_stackSize(0)
+	, m_stack(nullptr)
+	, m_stackPointer(nullptr)
+	, m_state(CoroutineState::Created)
+	, m_refCount(1)
+	, m_priorCoroutine(nullptr)
+{
+	m_stackPointer = CreateFiberEx(0, m_stackSize, 0, &CoroutineStatic::EntryPoint, &Coroutine::entryPoint_);
+}
+
+void sprawl::threading::Coroutine::Resume()
+{
+	m_holder->m_state = CoroutineState::Executing;
+
+	m_holder->m_priorCoroutine = *ms_thisThreadCoroutine;
+
+	ms_thisThreadCoroutine = *this;
+
+	m_holder->m_priorCoroutine.m_holder->m_state = CoroutineState::Paused;
+
+	ms_coroutineInitHelper = this;
+	SwitchToFiber(m_holder->m_stackPointer);
+}
+
+void sprawl::threading::Coroutine::reactivate_()
+{
+	m_holder->m_state = CoroutineState::Executing;
+
+	Coroutine currentlyActiveCoroutine = *ms_thisThreadCoroutine;
+	ms_thisThreadCoroutine = *this;
+
+	SwitchToFiber(m_holder->m_stackPointer);
+}
+
+void sprawl::threading::Coroutine::Pause()
+{
+	m_holder->m_state = CoroutineState::Paused;
+
+	ms_thisThreadCoroutine = m_holder->m_priorCoroutine;
+
+	m_holder->m_priorCoroutine.m_holder->m_state = CoroutineState::Executing;
+
+	SwitchToFiber(m_holder->m_priorCoroutine.m_holder->m_stackPointer);
+}

--- a/threading/thread.hpp
+++ b/threading/thread.hpp
@@ -11,6 +11,7 @@ namespace sprawl
 	{
 		class Thread;
 		class Handle;
+		void RunThread(Thread* thread);
 	}
 
 	namespace this_thread
@@ -24,6 +25,7 @@ namespace sprawl
 
 #ifdef _WIN32
 #	include "thread_windows.hpp"
+#	undef Yield
 #else
 #	include "thread_linux.hpp"
 #endif
@@ -54,10 +56,11 @@ public:
 
 	void Start();
 
-private:
-	static void* EntryPoint(void* data);
+protected:
 	void PlatformJoin();
 	void PlatformDetach();
+
+	friend void RunThread(Thread* thread);
 
 	char const* const m_threadName;
 	std::function<void()> m_function;
@@ -100,14 +103,6 @@ sprawl::threading::Thread::Thread(char const* const threadName, Function&& f)
 
 }
 
-inline sprawl::threading::Thread::~Thread()
-{
-	if(Joinable())
-	{
-		abort();
-	}
-}
-
 inline void sprawl::threading::Thread::Join()
 {
 	if(!Joinable())
@@ -128,9 +123,7 @@ inline void sprawl::threading::Thread::Detach()
 	m_handle = Handle();
 }
 
-inline /*static*/ void* sprawl::threading::Thread::EntryPoint(void *data)
+inline void sprawl::threading::RunThread(Thread* thread)
 {
-	Thread* thread = reinterpret_cast<Thread*>(data);
 	thread->m_function();
-	return nullptr;
 }

--- a/threading/thread_linux.cpp
+++ b/threading/thread_linux.cpp
@@ -2,6 +2,16 @@
 #include "../time/time.hpp"
 #include <time.h>
 
+namespace ThreadStatic
+{
+	static void* EntryPoint(void *data)
+	{
+		sprawl::threading::Thread* thread = reinterpret_cast<sprawl::threading::Thread*>(data);
+		sprawl::threading::RunThread(thread);
+		return nullptr;
+	}
+}
+
 int64_t sprawl::threading::Handle::GetUniqueId() const
 {
 	return int64_t(m_thread);
@@ -9,7 +19,7 @@ int64_t sprawl::threading::Handle::GetUniqueId() const
 
 void sprawl::threading::Thread::Start()
 {
-	int result = pthread_create(&m_handle.GetNativeHandle(), nullptr, &Thread::EntryPoint, this);
+	int result = pthread_create(&m_handle.GetNativeHandle(), nullptr, &ThreadStatic::EntryPoint, this);
 	if(result == 0)
 	{
 		if(m_threadName != nullptr)
@@ -33,6 +43,14 @@ void sprawl::threading::Thread::PlatformDetach()
 sprawl::threading::Handle sprawl::this_thread::GetHandle()
 {
 	return sprawl::threading::Handle(pthread_self());
+}
+
+sprawl::threading::Thread::~Thread()
+{
+	if(Joinable())
+	{
+		abort();
+	}
 }
 
 void sprawl::this_thread::Sleep(uint64_t nanoseconds)

--- a/threading/thread_linux.hpp
+++ b/threading/thread_linux.hpp
@@ -30,5 +30,3 @@ public:
 private:
 	pthread_t m_thread;
 };
-
-

--- a/threading/thread_windows.cpp
+++ b/threading/thread_windows.cpp
@@ -1,0 +1,92 @@
+#include "thread.hpp"
+#include "../time/time.hpp"
+
+namespace ThreadStatic
+{
+	static DWORD WINAPI EntryPoint(LPVOID data)
+	{
+		sprawl::threading::Thread* thread = reinterpret_cast<sprawl::threading::Thread*>(data);
+		sprawl::threading::RunThread(thread);
+		return 0;
+	}
+}
+
+int64_t sprawl::threading::Handle::GetUniqueId() const
+{
+	return GetThreadId(m_thread);
+}
+
+void sprawl::threading::Thread::Start()
+{
+	m_handle.GetNativeHandle() = CreateThread( nullptr, 0, &ThreadStatic::EntryPoint, this, 0, nullptr);
+	if(m_handle.GetNativeHandle() != INVALID_HANDLE_VALUE)
+	{
+		if(m_threadName != nullptr)
+		{
+			const DWORD MS_VC_EXCEPTION = 0x406D1388;
+
+#pragma pack(push,8)
+			struct THREADNAME_INFO
+			{
+				DWORD dwType; // Must be 0x1000.
+				LPCSTR szName; // Pointer to name (in user addr space).
+				DWORD dwThreadID; // Thread ID (-1=caller thread).
+				DWORD dwFlags; // Reserved for future use, must be zero.
+			};
+#pragma pack(pop)
+
+			THREADNAME_INFO info;
+			info.dwType = 0x1000;
+			info.szName = m_threadName;
+			info.dwThreadID = GetThreadId(m_handle.GetNativeHandle());
+			info.dwFlags = 0;
+
+			__try
+			{
+				RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
+			}
+			__except(EXCEPTION_EXECUTE_HANDLER)
+			{
+			}
+		}
+	}
+}
+
+void sprawl::threading::Thread::PlatformJoin()
+{
+	WaitForSingleObject(m_handle.GetNativeHandle(), INFINITE);
+}
+
+void sprawl::threading::Thread::PlatformDetach()
+{
+	CloseHandle(m_handle.GetNativeHandle());
+}
+
+sprawl::threading::Handle sprawl::this_thread::GetHandle()
+{
+	return sprawl::threading::Handle(GetCurrentThread());
+}
+
+sprawl::threading::Thread::~Thread()
+{
+	if(Joinable())
+	{
+		abort();
+	}
+	CloseHandle(m_handle.GetNativeHandle());
+}
+
+void sprawl::this_thread::Sleep(uint64_t nanoseconds)
+{
+	::Sleep(nanoseconds / sprawl::time::Resolution::Milliseconds);
+}
+
+void sprawl::this_thread::SleepUntil(uint64_t nanosecondTimestamp)
+{
+	Sleep(nanosecondTimestamp - sprawl::time::Now(sprawl::time::Resolution::Nanoseconds));
+}
+
+void sprawl::this_thread::Yield()
+{
+	SwitchToThread();
+}

--- a/threading/thread_windows.hpp
+++ b/threading/thread_windows.hpp
@@ -1,0 +1,46 @@
+#include <Windows.h>
+
+class sprawl::threading::Handle
+{
+public:
+	Handle()
+		: m_thread()
+		, duplicate(false)
+	{
+		//
+	}
+
+	Handle(HANDLE const& thread)
+		: m_thread(nullptr)
+		, duplicate(true)
+	{
+		DuplicateHandle(GetCurrentProcess(), thread, GetCurrentProcess(), &m_thread, 0, false, DUPLICATE_SAME_ACCESS);
+	}
+	
+	Handle(Handle const& other)
+		: m_thread(other.m_thread)
+		, duplicate(false)
+	{
+
+	}
+
+	~Handle()
+	{
+		if(duplicate)
+		{
+			CloseHandle(m_thread);
+		}
+	}
+
+	bool operator==(Handle const& other) { return m_thread == other.m_thread; }
+	bool operator!=(Handle const& other) { return m_thread != other.m_thread; }
+
+	int64_t GetUniqueId() const;
+	HANDLE& GetNativeHandle() { return m_thread; }
+	HANDLE const& GetNativeHandle() const { return m_thread; }
+private:
+	HANDLE m_thread;
+	bool duplicate;
+};
+
+

--- a/threading/threadlocal.hpp
+++ b/threading/threadlocal.hpp
@@ -1,0 +1,156 @@
+#pragma once
+
+namespace sprawl
+{
+	namespace threading
+	{
+		template<typename T>
+		class ThreadLocal;
+	}
+}
+
+#ifdef _WIN32
+#	include <Windows.h>
+#else
+#	include <pthread.h>
+#endif
+
+template<typename T>
+class sprawl::threading::ThreadLocal
+{
+public:
+	ThreadLocal();
+	ThreadLocal(T const& value);
+	~ThreadLocal();
+
+	void operator=(T const& value);
+
+	T& operator*();
+	T const& operator*() const;
+	T* operator->();
+	T const* operator->() const;
+
+	operator bool() const;
+private:
+	T* get();
+	T const* get() const;
+	void set(T const& value);
+
+	#ifdef _WIN32
+		typedef	DWORD KeyType;
+	#else
+		typedef pthread_key_t KeyType;
+	#endif
+
+	KeyType m_key;
+};
+
+template<typename T>
+class sprawl::threading::ThreadLocal<T*>
+{
+public:
+	ThreadLocal();
+	ThreadLocal(T const* value);
+	~ThreadLocal();
+
+	void operator=(T const* value);
+
+	T* operator*();
+	T const* operator*() const;
+	T* operator->();
+	T const* operator->() const;
+
+	operator bool() const;
+private:
+	T* get();
+	T const* get() const;
+	void set(T const* value);
+
+	#ifdef _WIN32
+		typedef	DWORD KeyType;
+	#else
+		typedef pthread_key_t KeyType;
+	#endif
+
+	KeyType m_key;
+};
+
+template<typename T>
+void sprawl::threading::ThreadLocal<T>::operator=(T const& value)
+{
+	set(value);
+}
+
+template<typename T>
+T& sprawl::threading::ThreadLocal<T>::operator*()
+{
+	return *get();
+}
+
+template<typename T>
+T const& sprawl::threading::ThreadLocal<T>::operator*() const
+{
+	return *get();
+}
+
+template<typename T>
+T* sprawl::threading::ThreadLocal<T>::operator->()
+{
+	return get();
+}
+
+template<typename T>
+T const* sprawl::threading::ThreadLocal<T>::operator->() const
+{
+	return get();
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T>::operator bool() const
+{
+	return get() != nullptr;
+}
+
+template<typename T>
+void sprawl::threading::ThreadLocal<T*>::operator=(T const* value)
+{
+	set(value);
+}
+
+template<typename T>
+T* sprawl::threading::ThreadLocal<T*>::operator*()
+{
+	return get();
+}
+
+template<typename T>
+T const* sprawl::threading::ThreadLocal<T*>::operator*() const
+{
+	return get();
+}
+
+template<typename T>
+T* sprawl::threading::ThreadLocal<T*>::operator->()
+{
+	return get();
+}
+
+template<typename T>
+T const* sprawl::threading::ThreadLocal<T*>::operator->() const
+{
+	return get();
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T*>::operator bool() const
+{
+	return get() != nullptr;
+}
+
+
+
+#ifdef _WIN32
+#	include "threadlocal_windows.inl"
+#else
+#	include "threadlocal_linux.inl"
+#endif

--- a/threading/threadlocal_linux.inl
+++ b/threading/threadlocal_linux.inl
@@ -1,0 +1,81 @@
+template<typename T>
+sprawl::threading::ThreadLocal<T>::ThreadLocal()
+{
+	pthread_key_create(&m_key, NULL);
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T>::ThreadLocal(T const& value)
+{
+	pthread_key_create(&m_key, NULL);
+	set(value);
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T>::~ThreadLocal()
+{
+	pthread_key_delete(m_key);
+}
+
+template<typename T>
+T* sprawl::threading::ThreadLocal<T>::get()
+{
+	return reinterpret_cast<T*>(pthread_getspecific(m_key));
+}
+
+template<typename T>
+T const* sprawl::threading::ThreadLocal<T>::get() const
+{
+	return reinterpret_cast<T*>(pthread_getspecific(m_key));
+}
+
+template<typename T>
+void sprawl::threading::ThreadLocal<T>::set(T const& value)
+{
+	T* oldValue = reinterpret_cast<T*>(pthread_getspecific(m_key));
+	if(oldValue)
+	{
+		*oldValue = value;
+	}
+	else
+	{
+		pthread_setspecific(m_key, (void*)(new T(value)));
+	}
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T*>::ThreadLocal()
+{
+	pthread_key_create(&m_key, NULL);
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T*>::ThreadLocal(T const* value)
+{
+	pthread_key_create(&m_key, NULL);
+	set(value);
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T*>::~ThreadLocal()
+{
+	pthread_key_delete(m_key);
+}
+
+template<typename T>
+T* sprawl::threading::ThreadLocal<T*>::get()
+{
+	return reinterpret_cast<T*>(pthread_getspecific(m_key));
+}
+
+template<typename T>
+T const* sprawl::threading::ThreadLocal<T*>::get() const
+{
+	return reinterpret_cast<T*>(pthread_getspecific(m_key));
+}
+
+template<typename T>
+void sprawl::threading::ThreadLocal<T*>::set(T const* value)
+{
+	pthread_setspecific(m_key, (void*)(value));
+}

--- a/threading/threadlocal_windows.inl
+++ b/threading/threadlocal_windows.inl
@@ -1,0 +1,81 @@
+template<typename T>
+sprawl::threading::ThreadLocal<T>::ThreadLocal()
+{
+	m_key = TlsAlloc();
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T>::ThreadLocal(T const& value)
+{
+	m_key = TlsAlloc();
+	set(value);
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T>::~ThreadLocal()
+{
+	TlsFree(m_key);
+}
+
+template<typename T>
+T* sprawl::threading::ThreadLocal<T>::get()
+{
+	return reinterpret_cast<T*>(TlsGetValue(m_key));
+}
+
+template<typename T>
+T const* sprawl::threading::ThreadLocal<T>::get() const
+{
+	return reinterpret_cast<T*>(TlsGetValue(m_key));
+}
+
+template<typename T>
+void sprawl::threading::ThreadLocal<T>::set(T const& value)
+{
+	T* oldValue = reinterpret_cast<T*>(TlsGetValue(m_key));
+	if(oldValue)
+	{
+		*oldValue = value;
+	}
+	else
+	{
+		TlsSetValue(m_key, (void*)(new T(value)));
+	}
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T*>::ThreadLocal()
+{
+	m_key = TlsAlloc();
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T*>::ThreadLocal(T const* value)
+{
+	m_key = TlsAlloc();
+	set(value);
+}
+
+template<typename T>
+sprawl::threading::ThreadLocal<T*>::~ThreadLocal()
+{
+	TlsFree(m_key);
+}
+
+template<typename T>
+T* sprawl::threading::ThreadLocal<T*>::get()
+{
+	return reinterpret_cast<T*>(TlsGetValue(m_key));
+}
+
+template<typename T>
+T const* sprawl::threading::ThreadLocal<T*>::get() const
+{
+	return reinterpret_cast<T*>(TlsGetValue(m_key));
+}
+
+template<typename T>
+void sprawl::threading::ThreadLocal<T*>::set(T const* value)
+{
+	TlsSetValue(m_key, (void*)(value));
+}

--- a/time/time_windows.cpp
+++ b/time/time_windows.cpp
@@ -1,6 +1,7 @@
-
+#include "time.hpp"
 #include <Windows.h>
 #include <Winbase.h>
+#include <type_traits>
 
 namespace sprawl
 {


### PR DESCRIPTION
- Windows implementations of thread and time libraries
- Added coroutines
- Added some more unit tests, fixed some unit tests in windows environments
- Fixed an issue where multi threading was not properly detected on Linux
- Fixed the makefiles to build with threading by default on linux
- Changed the pool allocator to use thread-local pools instead of locking mutexes
- Fixed output of sprawl::string in the StringBuilder library to take length into account
- Added string builder options for StringLiteral
- Added thread local implementation